### PR TITLE
Add support for skipped workflow state

### DIFF
--- a/lambda/app.d.ts
+++ b/lambda/app.d.ts
@@ -8,7 +8,8 @@ declare global {
     | "POST_MIGRATIONS"
     | "STOPPED"
     | "FAILED"
-    | "SUCCEEDED";
+    | "SUCCEEDED"
+    | "SKIPPED";
 
   interface GitHubActionsEvent {
     state: GithubActionsEventState;

--- a/lambda/constants.ts
+++ b/lambda/constants.ts
@@ -7,6 +7,7 @@ export enum WorkflowState {
   finished = "finished",
   stopped = "stopped",
   failed = "failed",
+  skipped = "skipped",
 }
 
 export const COLORS = {

--- a/lambda/index.ts
+++ b/lambda/index.ts
@@ -17,9 +17,10 @@ const STATE_MESSAGES: { [k in keyof typeof WorkflowState]: [color: string, getSt
   finished:                [COLORS.success, ref => `*Finished* deploying ${ref}`],
   stopped:                 [COLORS.warning, ref => `Deployment *stopped* for ${ref}`],
   failed:                  [COLORS.error,   ref => `Deployment *failed* for ${ref}`],
+  skipped:                 [COLORS.warning, ref => `Deployment *skipped* for ${ref}`],
 };
 
-const ENDING_STATES: WorkflowState[] = [WorkflowState.finished, WorkflowState.stopped, WorkflowState.failed];
+const ENDING_STATES: WorkflowState[] = [WorkflowState.finished, WorkflowState.stopped, WorkflowState.failed, WorkflowState.skipped];
 
 let lambdaCallback: Callback<LambdaResponse> | undefined = undefined;
 

--- a/lambda/workflows/github-actions.ts
+++ b/lambda/workflows/github-actions.ts
@@ -9,6 +9,7 @@ const GH_ACTIONS_EXECUTION_STATES: { [k in GithubActionsEventState]: WorkflowSta
   STOPPED: WorkflowState.stopped,
   FAILED: WorkflowState.failed,
   SUCCEEDED: WorkflowState.finished,
+  SKIPPED: WorkflowState.skipped,
 };
 
 export class GithubActionsWorkflow extends Workflow<GitHubActionsEvent> {


### PR DESCRIPTION
## Goal
The goal of this PR is to add a new Github actions event state. 
The new state is `skipped` and is used to describe a current deployment that is skipped since a newer deployment was triggered.

The word `skipped` was chosen since it is general enough to be used in other scenarios. 
Do you like this word or do you have any suggestion ?

## todo
- [x] Create a release